### PR TITLE
do not enforce SSL on nginx level

### DIFF
--- a/swarm/values.yaml
+++ b/swarm/values.yaml
@@ -76,6 +76,7 @@ swarm:
     domain: default.swarm-gateways.net
     annotations:
       nginx.ingress.kubernetes.io/proxy-body-size: 20m
+      nginx.ingress.kubernetes.io/ssl-redirect: "false"
 
 jaeger:
   image:


### PR DESCRIPTION
We have HSTS headers on the website, but I'd rather we don't enforce SSL on nginx level, so that we simplify testing of Swarm.