### PR TITLE
swarm-private: small fixes

### DIFF
--- a/swarm-private/templates/swarm.statefulset.yaml
+++ b/swarm-private/templates/swarm.statefulset.yaml
@@ -39,7 +39,7 @@ spec:
         - sh
         - -ac
         - >
-          export BOOTNODE_IP=$(nslookup {{ template "swarm.fullname" . }}-bootnode.{{ .Release.Namespace }} | grep Address | awk '{ print $3 }') &&
+          export BOOTNODE_IP=$(nslookup {{ template "swarm.fullname" . }}-bootnode | grep Address | awk '{ print $3 }') &&
           /run.sh
           --ens-api={{ .Values.swarm.config.ens_api }}
           --port=30399

--- a/swarm-private/values.yaml
+++ b/swarm-private/values.yaml
@@ -2,9 +2,6 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-# DNS domain used by the kubernetes cluster
-k8sDNSDomain: cluster.local
-
 bootnode:
   # Image configuration
   image:


### PR DESCRIPTION
- Removing an unused variable
- Removing .Release.Namespace from DNS name since it's not needed when running pods in the same namespace