### PR TITLE
Better generation for the `index.yaml` when executing "helm repo index"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 *.tgz
-
+artifacts

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,16 +3,8 @@ language: generic
 dist: trusty
 sudo: false
 
-env:
-  global:
-    - HELM_VERSION="v2.11.0"
-
-install:
-  - wget http://storage.googleapis.com/kubernetes-helm/helm-${HELM_VERSION}-linux-amd64.tar.gz -O /tmp/helm.tar.gz
-  - tar xzf /tmp/helm.tar.gz -C /tmp --strip-components=1
-  - chmod +x /tmp/helm
-  - PATH=/tmp/:$PATH
-  - helm init --client-only
+services:
+  - docker
 
 script:
-  - helm lint */
+  - make lint

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,19 @@
+PWD=$(shell pwd)
+
+HELM_VERSION="2.11.0"
+
+HELM_DOCKER_IMAGE=alpine/helm:$(HELM_VERSION)
+SHELLCHECK_DOCKER_IMAGE=koalaman/shellcheck
+
+SHELLCHECK=docker run -it --rm -w /scripts -v $(PWD):/scripts $(SHELLCHECK_DOCKER_IMAGE)
+HELM=docker run -it --rm -v $(PWD):/apps $(HELM_DOCKER_IMAGE)
+
+.PHONY: lint docker-deps
+
+lint: docker-deps
+	$(HELM) lint $(shell dirname */Chart.yaml)
+	$(SHELLCHECK) *.sh
+
+docker-deps:
+	docker pull $(SHELLCHECK_DOCKER_IMAGE)
+	docker pull $(HELM_DOCKER_IMAGE)

--- a/package.sh
+++ b/package.sh
@@ -1,18 +1,20 @@
 #!/bin/sh -xe
 
 ARTIFACTS_DIR="artifacts"
+CHART_REPO_URL="https://raw.githubusercontent.com/ethersphere/helm-charts-artifacts/master/"
 
 if [ ! -d $ARTIFACTS_DIR ] ; then
   git clone git@github.com:ethersphere/helm-charts-artifacts.git $ARTIFACTS_DIR
 fi
 
-helm repo add ethersphere https://raw.githubusercontent.com/ethersphere/helm-charts-artifacts/master/
+helm repo add ethersphere $CHART_REPO_URL
 helm repo update
 
-for chart in jaeger geth swarm swarm-private
+for chart in */Chart.yaml
 do
-  helm dependency update $chart
-  helm package $chart -d $ARTIFACTS_DIR
+  chart=$(dirname "$chart")
+  helm dependency update "$chart"
+  helm package "$chart" -d "$ARTIFACTS_DIR"
 done
 
-helm repo index $ARTIFACTS_DIR
+helm repo index --url "$CHART_REPO_URL" --merge "$ARTIFACTS_DIR/index.yaml" "$ARTIFACTS_DIR"


### PR DESCRIPTION
This PR improves the helm repo index generation because now it takes in consideration the previously existing `index.yaml`. Previously it was updating the timestamps of existing charts even when there were no changes to them.

Additionally, I've added a `Makefile` that for now is mainly used for linting (helm lint + shellcheck). This  made the CI scripts smaller because now it only needs to call `make lint`.