### PR TITLE
swarm-private: add smoke test cron job

### DIFF
--- a/swarm-private/templates/smoke.cronjob.yaml
+++ b/swarm-private/templates/smoke.cronjob.yaml
@@ -27,6 +27,6 @@ spec:
             - --filesize={{ .Values.smoke.size }}
             - --verbosity=5
             - c
-          restartPolicy: OnFailure
+          restartPolicy: Never
 
 {{- end }}

--- a/swarm-private/templates/smoke.cronjob.yaml
+++ b/swarm-private/templates/smoke.cronjob.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.smoke.enabled -}}
+
+{{- $root := . -}}
+
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: {{ template "swarm.fullname" $root }}-smoke
+  labels:
+    app: {{ template "swarm.name" $root }}
+spec:
+  schedule: "{{ $root.Values.smoke.schedule }}"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: smoke
+            image: ethdevops/swarm-smoke
+            imagePullPolicy: Always
+            args:
+            - --cluster-endpoint={{ $root.Release.Namespace }}
+            - --app={{ template "swarm.fullname" $root }}
+            - --cluster-from=0
+            - --cluster-to={{ $root.Values.swarm.replicaCount }}
+            - --cluster-scheme=http
+            - --filesize={{ .Values.smoke.size }}
+            - --verbosity=5
+            - c
+          restartPolicy: OnFailure
+
+{{- end }}

--- a/swarm-private/values.yaml
+++ b/swarm-private/values.yaml
@@ -26,6 +26,11 @@ bootnode:
   tolerations: []
   affinity: {}
 
+smoke:
+  enabled: false
+  schedule: "*/5 * * * *"
+  size: 110
+
 swarm:
   # Metrics: If enabled it will deploy a InfluxDB + Grafana stack.
   # All swarm nodes will forward metrics to the deploy InfluxDB instance
@@ -538,10 +543,10 @@ grafana:
   ##
   dashboards:
     default:
-      lbstore:
-        url: https://raw.githubusercontent.com/ethereum/go-ethereum/master/swarm/grafana_dashboards/ldbstore.json
+      ldbstore:
+        url: https://raw.githubusercontent.com/ethersphere/grafana-dashboards/master/ldbstore.json
       swarm:
-        url: https://raw.githubusercontent.com/ethereum/go-ethereum/master/swarm/grafana_dashboards/swarm.json
+        url: https://raw.githubusercontent.com/ethersphere/grafana-dashboards/master/swarm.json
 
   ## Reference to external ConfigMap per provider. Use provider name as key and ConfiMap name as value.
   ## A provider dashboards must be defined either by external ConfigMaps or in values.yaml, not in both.

--- a/swarm/values.yaml
+++ b/swarm/values.yaml
@@ -517,10 +517,10 @@ grafana:
   ##
   dashboards:
     default:
-      lbstore:
-        url: https://raw.githubusercontent.com/ethereum/go-ethereum/master/swarm/grafana_dashboards/ldbstore.json
+      ldbstore:
+        url: https://raw.githubusercontent.com/ethersphere/grafana-dashboards/master/ldbstore.json
       swarm:
-        url: https://raw.githubusercontent.com/ethereum/go-ethereum/master/swarm/grafana_dashboards/swarm.json
+        url: https://raw.githubusercontent.com/ethersphere/grafana-dashboards/master/swarm.json
 
   ## Reference to external ConfigMap per provider. Use provider name as key and ConfiMap name as value.
   ## A provider dashboards must be defined either by external ConfigMaps or in values.yaml, not in both.


### PR DESCRIPTION
This PR is adding a CronJob to the `swarm-private` chart, which when enabled with run `swarm-smoke` tests on the given deployment.

Also updates the location of our Grafana dashboards.