### PR TITLE
get local ip for swarm private

### DIFF
--- a/swarm-private/templates/smoke.cronjob.yaml
+++ b/swarm-private/templates/smoke.cronjob.yaml
@@ -38,13 +38,16 @@ spec:
             - --cluster-to={{ $root.Values.swarm.replicaCount }}
             - --cluster-scheme=http
             - --filesize={{ .Values.smoke.config.filesize }}
+            - --filesize={{ .Values.smoke.config.filesize }}
+            - --single
+            - --sync-delay={{ .Values.smoke.config.syncdelay }}
             - --verbosity=5
             - --metrics
             - --metrics.influxdb.endpoint=http://{{ template "swarm.influxdb.fullname" . }}:8086
             - --metrics.influxdb.username={{ .Values.influxdb.setDefaultUser.user.username }}
             - --metrics.influxdb.password={{ .Values.influxdb.setDefaultUser.user.password }}
             - --metrics.influxdb.database=metrics
-            - --metrics.influxdb.host.tag=$(POD_NAME)
+            - --metrics.influxdb.host.tag=single
             - c
           restartPolicy: Never
 

--- a/swarm-private/templates/swarm.statefulset.yaml
+++ b/swarm-private/templates/swarm.statefulset.yaml
@@ -40,6 +40,7 @@ spec:
         - -ac
         - >
           export BOOTNODE_IP=$(nslookup {{ template "swarm.fullname" . }}-bootnode | grep Address | awk '{ print $3 }') &&
+          export LOCAL_IP=$(wget http://169.254.169.254/latest/meta-data/local-ipv4 -q -O -) &&
           /run.sh
           --ens-api={{ .Values.swarm.config.ens_api }}
           --port=30399
@@ -48,6 +49,8 @@ spec:
           --corsdomain=*
           --httpaddr=0.0.0.0
           --wsport=8546
+          --vmodule="p2p=5"
+          --nat=extip:$LOCAL_IP
           --verbosity={{ .Values.swarm.config.verbosity }}
           --maxpeers={{ .Values.swarm.config.maxpeers }}
           --ipcpath=bzzd.ipc

--- a/swarm-private/values.yaml
+++ b/swarm-private/values.yaml
@@ -51,6 +51,8 @@ smoke:
   failedJobsHistoryLimit: 3
   config:
     filesize: 110 # file size for generated random file in KB
+    syncdelay: 5
+    single: false
   ## Configure resource requests and limits
   ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
   resources: {}


### PR DESCRIPTION
enode is not detected correctly, unless we specify `natip`