### PR TITLE
swarm-private: use pod IP on nat flag

### DIFF
--- a/swarm-private/templates/swarm.statefulset.yaml
+++ b/swarm-private/templates/swarm.statefulset.yaml
@@ -40,7 +40,6 @@ spec:
         - -ac
         - >
           export BOOTNODE_IP=$(nslookup {{ template "swarm.fullname" . }}-bootnode | grep Address | awk '{ print $3 }') &&
-          export LOCAL_IP=$(wget http://169.254.169.254/latest/meta-data/local-ipv4 -q -O -) &&
           /run.sh
           --ens-api={{ .Values.swarm.config.ens_api }}
           --port=30399
@@ -49,7 +48,7 @@ spec:
           --corsdomain=*
           --httpaddr=0.0.0.0
           --wsport=8546
-          --nat=extip:$LOCAL_IP
+          --nat=ip:$POD_IP
           --verbosity={{ .Values.swarm.config.verbosity }}
           --maxpeers={{ .Values.swarm.config.maxpeers }}
           --ipcpath=bzzd.ipc
@@ -82,6 +81,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
         - name: PASSWORD
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION
Currently it's using the host IP address, instead it should use the pod IP address.

I also tried setting `-nat=none` because all our swarm pods belong to the same network (LAN), therefore it doesn't make sense to talk about NAT. But this was still setting the enodes IP address to 127.0.0.1.

