### PR TITLE
Allow using default tls certficiates provided by the ingress controller

### DIFF
--- a/swarm-private/templates/swarm.ingress.yaml
+++ b/swarm-private/templates/swarm.ingress.yaml
@@ -9,15 +9,17 @@ metadata:
   annotations:
     kubernetes.io/ingress.class: "nginx"
 {{ toYaml .Values.swarm.ingress.annotations | indent 4 }}
-{{- if $root.Values.swarm.ingress.tls.acmeEnabled }}
+{{- if and ($root.Values.swarm.ingress.tls.enabled) ($root.Values.swarm.ingress.tls.acmeEnabled) }}
     kubernetes.io/tls-acme: "true"
 {{- end }}
 spec:
-{{- if $root.Values.swarm.ingress.tls.acmeEnabled }}
+{{- if $root.Values.swarm.ingress.tls.enabled }}
   tls:
   - hosts:
       - {{ template "swarm.fullname" $root }}-{{ $root.Release.Namespace }}.{{ $root.Values.swarm.ingress.domain }}
+  {{- if $root.Values.swarm.ingress.tls.acmeEnabled }}
     secretName: {{ template "swarm.fullname" $root }}-ingress-tls
+  {{- end }}
 {{- end }}
   rules:
   - host: {{ template "swarm.fullname" $root }}-{{ $root.Release.Namespace }}.{{ $root.Values.swarm.ingress.domain }}
@@ -38,15 +40,17 @@ metadata:
   annotations:
     kubernetes.io/ingress.class: "nginx"
 {{ toYaml $root.Values.swarm.ingress.annotations | indent 4 }}
-{{- if $root.Values.swarm.ingress.tls.acmeEnabled }}
+{{- if and ($root.Values.swarm.ingress.tls.enabled) ($root.Values.swarm.ingress.tls.acmeEnabled) }}
     kubernetes.io/tls-acme: "true"
 {{- end }}
 spec:
-{{- if $root.Values.swarm.ingress.tls.acmeEnabled }}
+{{- if $root.Values.swarm.ingress.tls.enabled }}
   tls:
   - hosts:
       - {{ template "swarm.fullname" $root }}-{{ $i }}-{{ $root.Release.Namespace }}.{{ $root.Values.swarm.ingress.domain }}
+  {{- if $root.Values.swarm.ingress.tls.acmeEnabled }}
     secretName: {{ template "swarm.fullname" $root }}-ingress-tls-{{ $i }}
+  {{- end }}
 {{- end }}
   rules:
   - host: {{ template "swarm.fullname" $root }}-{{ $i }}-{{ $root.Release.Namespace }}.{{ $root.Values.swarm.ingress.domain }}
@@ -58,4 +62,3 @@ spec:
           servicePort: 8500
 {{- end }}
 {{- end }}
-

--- a/swarm-private/values.yaml
+++ b/swarm-private/values.yaml
@@ -92,7 +92,8 @@ swarm:
   ingress:
     enabled: true
     tls:
-      acmeEnabled: false
+      enabled: false
+      acmeEnabled: false # Use cert-manager to generate certificates via ACME
     domain: default.swarm-gateways.net
     annotations:
       nginx.ingress.kubernetes.io/proxy-body-size: 20m

--- a/swarm/templates/swarm.ingress.yaml
+++ b/swarm/templates/swarm.ingress.yaml
@@ -9,15 +9,17 @@ metadata:
   annotations:
     kubernetes.io/ingress.class: "nginx"
 {{ toYaml .Values.swarm.ingress.annotations | indent 4 }}
-{{- if $root.Values.swarm.ingress.tls.acmeEnabled }}
+{{- if and ($root.Values.swarm.ingress.tls.enabled) ($root.Values.swarm.ingress.tls.acmeEnabled) }}
     kubernetes.io/tls-acme: "true"
 {{- end }}
 spec:
-{{- if $root.Values.swarm.ingress.tls.acmeEnabled }}
+{{- if $root.Values.swarm.ingress.tls.enabled }}
   tls:
   - hosts:
       - {{ template "swarm.fullname" $root }}-{{ $root.Release.Namespace }}.{{ $root.Values.swarm.ingress.domain }}
+  {{- if $root.Values.swarm.ingress.tls.acmeEnabled }}
     secretName: {{ template "swarm.fullname" $root }}-ingress-tls
+  {{- end }}
 {{- end }}
   rules:
   - host: {{ template "swarm.fullname" $root }}-{{ $root.Release.Namespace }}.{{ $root.Values.swarm.ingress.domain }}
@@ -38,15 +40,17 @@ metadata:
   annotations:
     kubernetes.io/ingress.class: "nginx"
 {{ toYaml $root.Values.swarm.ingress.annotations | indent 4 }}
-{{- if $root.Values.swarm.ingress.tls.acmeEnabled }}
+{{- if and ($root.Values.swarm.ingress.tls.enabled) ($root.Values.swarm.ingress.tls.acmeEnabled) }}
     kubernetes.io/tls-acme: "true"
 {{- end }}
 spec:
-{{- if $root.Values.swarm.ingress.tls.acmeEnabled }}
+{{- if $root.Values.swarm.ingress.tls.enabled }}
   tls:
   - hosts:
       - {{ template "swarm.fullname" $root }}-{{ $i }}-{{ $root.Release.Namespace }}.{{ $root.Values.swarm.ingress.domain }}
+  {{- if $root.Values.swarm.ingress.tls.acmeEnabled }}
     secretName: {{ template "swarm.fullname" $root }}-ingress-tls-{{ $i }}
+  {{- end }}
 {{- end }}
   rules:
   - host: {{ template "swarm.fullname" $root }}-{{ $i }}-{{ $root.Release.Namespace }}.{{ $root.Values.swarm.ingress.domain }}

--- a/swarm/values.yaml
+++ b/swarm/values.yaml
@@ -72,7 +72,8 @@ swarm:
   ingress:
     enabled: true
     tls:
-      acmeEnabled: false
+      enabled: false
+      acmeEnabled: false # Use cert-manager to generate certificates via ACME
     domain: default.swarm-gateways.net
     annotations:
       nginx.ingress.kubernetes.io/proxy-body-size: 20m


### PR DESCRIPTION
swarm: allow using the default nginx certificate by enabling tls but leaving acme disabled.