### PR TITLE
smoke cron job: generic extra flags

### DIFF
--- a/smoke/templates/smoke.cronjob.yaml
+++ b/smoke/templates/smoke.cronjob.yaml
@@ -26,20 +26,20 @@ spec:
             resources:
 {{ toYaml .Values.smoke.resources | indent 14 }}
             args:
-            - --cluster-endpoint={{ $root.Release.Namespace }}
             - --app={{ .Values.smoke.config.target }}
+            - --verbosity=5
+            - --cluster-endpoint={{ $root.Release.Namespace }}
             - --cluster-from=0
             - --cluster-to={{ .Values.smoke.config.swarmReplicas }}
             - --cluster-scheme=http
-            - --filesize={{ .Values.smoke.config.filesize }}
-            - --single
-            - --sync-delay={{ .Values.smoke.config.syncdelay }}
-            - --verbosity=5
             - --metrics
             - --metrics.influxdb.endpoint={{ .Values.smoke.config.influxdbEndpoint }}
             - --metrics.influxdb.username={{ .Values.smoke.config.influxdbUsername }}
             - --metrics.influxdb.password={{ .Values.smoke.config.influxdbPassword }}
             - --metrics.influxdb.database=metrics
-            - --metrics.influxdb.host.tag=single-{{ .Values.smoke.config.syncdelay }}-{{ .Values.smoke.config.filesize }}
+            - --metrics.influxdb.host.tag={{ .Values.smoke.config.name }}
+{{- range $i, $flag := .Values.smoke.config.extraFlags }}
+            - {{ $flag }}
+{{- end }}
             - {{ .Values.smoke.config.operation }}
           restartPolicy: Never

--- a/smoke/values.yaml
+++ b/smoke/values.yaml
@@ -25,13 +25,17 @@ smoke:
   failedJobsHistoryLimit: 3
   config:
     target: "swarm-private" # target application name (generally swarm or swarm-private)
-    filesize: 110 # file size for generated random file in KB
-    syncdelay: 5
     swarmReplicas: 5
     influxdbUsername: "swarm"
     influxdbPassword: "swarm"
     influxdbEndpoint: "http://swarm-influxdb:8086"
-    operation: upload_and_sync # smoke test operation that we want to run
+    operation: "upload_and_sync" # smoke test operation that we want to run
+    name: "upload-sync-50-5-30"
+    extraFlags:
+      - --single
+      - --filesize=50
+      - --sync-delay=30
+
   ## Configure resource requests and limits
   ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
   resources: {}


### PR DESCRIPTION
Abstracting away all the extra flags we pass to `swarm-smoke` and making the cronjob configurable directly from the `yaml` override.