### PR TITLE
swarm-private chart: change bootnode to swarm bootnode

### DIFF
--- a/swarm-private/templates/bootnode.statefulset.yaml
+++ b/swarm-private/templates/bootnode.statefulset.yaml
@@ -48,6 +48,7 @@ spec:
           --nat=ip:$POD_IP
           --port=30301
           --bzznetworkid={{ .Values.bootnode.config.bzznetworkid }}
+          # Non-existent bootnode until we have a way to specify that we want empty bootnodes list, see https://github.com/ethereum/go-ethereum/pull/18509
           --bootnodes=enode://1519bbd8251a4f3a0a2aa1f62b08741ded86ca8d4f08ade1fd3447866816ce129f3dae84b8078d2a6a6d41764c2ebb39ec608695fa588912b84025fd514f8ab0@10.255.255.212:33399
 {{- range $i, $flag := .Values.bootnode.config.extraFlags }}
           {{ $flag }}

--- a/swarm-private/templates/bootnode.statefulset.yaml
+++ b/swarm-private/templates/bootnode.statefulset.yaml
@@ -47,7 +47,7 @@ spec:
           --maxpeers=5000
           --nat=ip:$POD_IP
           --port=30301
-          --bzznetworkid={{ .Values.bootnode.config.bzznetworkid }}
+          --bzznetworkid={{ .Values.swarm.config.bzznetworkid }}
           # Non-existent bootnode until we have a way to specify that we want empty bootnodes list, see https://github.com/ethereum/go-ethereum/pull/18509
           --bootnodes=enode://1519bbd8251a4f3a0a2aa1f62b08741ded86ca8d4f08ade1fd3447866816ce129f3dae84b8078d2a6a6d41764c2ebb39ec608695fa588912b84025fd514f8ab0@10.255.255.212:33399
 {{- range $i, $flag := .Values.bootnode.config.extraFlags }}

--- a/swarm-private/templates/bootnode.statefulset.yaml
+++ b/swarm-private/templates/bootnode.statefulset.yaml
@@ -44,11 +44,11 @@ spec:
           --bootnode-mode
           --nodekey=/keys/bootnode.key
           --verbosity={{ .Values.bootnode.config.verbosity }}
-          --maxpeers 2000
+          --maxpeers=5000
           --nat=ip:$POD_IP
           --port=30301
           --bzznetworkid={{ .Values.bootnode.config.bzznetworkid }}
-          --bootnodes=enode://0db3ed33199e4168944c2c0a2b5994c8521ccb942f43fb432f481d88a02c6dee71d4e1da3727a29d4952d7653c862f74c6822d68abf6ae63d9251bbece8b87a5@10.0.55.155:30499
+          --bootnodes=""
 {{- range $i, $flag := .Values.bootnode.config.extraFlags }}
           {{ $flag }}
 {{- end }}

--- a/swarm-private/templates/bootnode.statefulset.yaml
+++ b/swarm-private/templates/bootnode.statefulset.yaml
@@ -49,6 +49,9 @@ spec:
           --port=30301
           --bzznetworkid={{ .Values.bootnode.config.bzznetworkid }}
           --bootnodes=enode://0db3ed33199e4168944c2c0a2b5994c8521ccb942f43fb432f481d88a02c6dee71d4e1da3727a29d4952d7653c862f74c6822d68abf6ae63d9251bbece8b87a5@10.0.55.155:30499
+{{- range $i, $flag := .Values.bootnode.config.extraFlags }}
+          {{ $flag }}
+{{- end }}
         env:
         - name: POD_NAME
           valueFrom:

--- a/swarm-private/templates/bootnode.statefulset.yaml
+++ b/swarm-private/templates/bootnode.statefulset.yaml
@@ -39,15 +39,30 @@ spec:
         - sh
         - -ac
         - >
-          /bootnode
+          /run.sh
+          --debug
+          --bootnode-mode
           --nodekey=/keys/bootnode.key
-          --addr=:30301
           --verbosity={{ .Values.bootnode.config.verbosity }}
+          --maxpeers 2000
+          --nat=ip:$POD_IP
+          --port=30301
+          --bzznetworkid={{ .Values.bootnode.config.bzznetworkid }}
+          --bootnodes=enode://0db3ed33199e4168944c2c0a2b5994c8521ccb942f43fb432f481d88a02c6dee71d4e1da3727a29d4952d7653c862f74c6822d68abf6ae63d9251bbece8b87a5@10.0.55.155:30499
         env:
         - name: POD_NAME
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        - name: PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ template "swarm.fullname" . }}
+              key: PASSWORD
         ports:
         - name: network
           containerPort: 30301

--- a/swarm-private/templates/bootnode.statefulset.yaml
+++ b/swarm-private/templates/bootnode.statefulset.yaml
@@ -48,7 +48,7 @@ spec:
           --nat=ip:$POD_IP
           --port=30301
           --bzznetworkid={{ .Values.bootnode.config.bzznetworkid }}
-          --bootnodes=""
+          --bootnodes=enode://1519bbd8251a4f3a0a2aa1f62b08741ded86ca8d4f08ade1fd3447866816ce129f3dae84b8078d2a6a6d41764c2ebb39ec608695fa588912b84025fd514f8ab0@10.255.255.212:33399
 {{- range $i, $flag := .Values.bootnode.config.extraFlags }}
           {{ $flag }}
 {{- end }}

--- a/swarm-private/templates/swarm.statefulset.yaml
+++ b/swarm-private/templates/swarm.statefulset.yaml
@@ -66,6 +66,7 @@ spec:
           --metrics.influxdb.username={{ .Values.influxdb.setDefaultUser.user.username }}
           --metrics.influxdb.password={{ .Values.influxdb.setDefaultUser.user.password }}
           --metrics.influxdb.database=metrics
+          --metrics.influxdb.host.tag=$(POD_NAME)
       {{- end }}
       {{- if .Values.swarm.tracingEnabled }}
           --tracing

--- a/swarm-private/templates/swarm.statefulset.yaml
+++ b/swarm-private/templates/swarm.statefulset.yaml
@@ -66,7 +66,6 @@ spec:
           --metrics.influxdb.username={{ .Values.influxdb.setDefaultUser.user.username }}
           --metrics.influxdb.password={{ .Values.influxdb.setDefaultUser.user.password }}
           --metrics.influxdb.database=metrics
-          --metrics.influxdb.host.tag=$(POD_NAME)
       {{- end }}
       {{- if .Values.swarm.tracingEnabled }}
           --tracing

--- a/swarm-private/values.yaml
+++ b/swarm-private/values.yaml
@@ -5,7 +5,7 @@
 bootnode:
   # Image configuration
   image:
-    repository: ethdevops/bootnode
+    repository: ethdevops/swarm
     tag: latest
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
@@ -13,9 +13,11 @@ bootnode:
   ##
   imagePullPolicy: Always
   config:
-    verbosity: 2
+    verbosity: 3
     publicaddr: 846c424961adc146d54861bdf1eb6015e6908b689fd12d01c61307fffc848c22e514f5c898dc9243fbb17aa80750b556772599d84fe86a4b715f40ebc4c049bf
     nodekey: 09a28f7be03b782768ae2a8e2de90e7e27cd643a60f2a68e57514097bfa23566
+    # Network identifier
+    bzznetworkid: 300
   ## Configure resource requests and limits
   ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
   resources: {}

--- a/swarm-private/values.yaml
+++ b/swarm-private/values.yaml
@@ -16,8 +16,6 @@ bootnode:
     verbosity: 3
     publicaddr: 846c424961adc146d54861bdf1eb6015e6908b689fd12d01c61307fffc848c22e514f5c898dc9243fbb17aa80750b556772599d84fe86a4b715f40ebc4c049bf
     nodekey: 09a28f7be03b782768ae2a8e2de90e7e27cd643a60f2a68e57514097bfa23566
-    # Network identifier
-    bzznetworkid: 300
     extraFlags: []
   ## Configure resource requests and limits
   ## ref: http://kubernetes.io/docs/user-guide/compute-resources/

--- a/swarm-private/values.yaml
+++ b/swarm-private/values.yaml
@@ -18,6 +18,7 @@ bootnode:
     nodekey: 09a28f7be03b782768ae2a8e2de90e7e27cd643a60f2a68e57514097bfa23566
     # Network identifier
     bzznetworkid: 300
+    extraFlags: []
   ## Configure resource requests and limits
   ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
   resources: {}


### PR DESCRIPTION
Switching `bootnode` with `swarm --bootnode-mode`, so that our bootnodes actually run the `hive` protocol, and discovery in Swarm works with `hive`, rather than with the `p2p` discovery functionality.