### PR TITLE
swarm: allow setting update stategy for statefulsets

### DIFF
--- a/swarm-private/templates/swarm.statefulset.yaml
+++ b/swarm-private/templates/swarm.statefulset.yaml
@@ -12,6 +12,7 @@ spec:
   serviceName: {{ template "swarm.fullname" . }}-headless
   replicas: {{ .Values.swarm.replicaCount }}
   podManagementPolicy: {{ .Values.swarm.podManagementPolicy }}
+  updateStrategy: {{ .Values.swarm.updateStrategy }}
   selector:
     matchLabels:
       app: {{ template "swarm.name" . }}

--- a/swarm-private/values.yaml
+++ b/swarm-private/values.yaml
@@ -49,6 +49,9 @@ swarm:
   # Pod management policy
   # https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#pod-management-policies
   podManagementPolicy: OrderedReady  # Choose between "OrderedReady" or "Parallel"
+  # Update strategy:
+  # https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#update-strategies
+  updateStrategy: "RollingUpdate"
   # Duration in seconds the pod needs to terminate gracefully
   terminationGracePeriodSeconds: 30
   config:

--- a/swarm/templates/swarm.statefulset.yaml
+++ b/swarm/templates/swarm.statefulset.yaml
@@ -12,6 +12,7 @@ spec:
   serviceName: {{ template "swarm.fullname" . }}-headless
   replicas: {{ .Values.swarm.replicaCount }}
   podManagementPolicy: {{ .Values.swarm.podManagementPolicy }}
+  updateStrategy: {{ .Values.swarm.updateStrategy }}
   selector:
     matchLabels:
       app: {{ template "swarm.name" . }}

--- a/swarm/values.yaml
+++ b/swarm/values.yaml
@@ -24,6 +24,9 @@ swarm:
   # Pod management policy
   # https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#pod-management-policies
   podManagementPolicy: OrderedReady  # Choose between "OrderedReady" or "Parallel"
+  # Update strategy:
+  # https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#update-strategies
+  updateStrategy: "RollingUpdate"
    # Duration in seconds the pod needs to terminate gracefully
   terminationGracePeriodSeconds: 30
   config:


### PR DESCRIPTION
Will allow us to set the `OnDelete` stategy if needed. So that we can deploy faster.

https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#update-strategies 