### PR TITLE
swarm: new metrics flag that allows setting multiple tags

### DIFF
--- a/swarm-private/Chart.yaml
+++ b/swarm-private/Chart.yaml
@@ -1,5 +1,5 @@
 name: swarm-private
-version: 0.0.1
+version: 0.0.2
 description: Create a private ethereum swarm cluster
 keywords:
 - ethereum

--- a/swarm-private/templates/swarm.statefulset.yaml
+++ b/swarm-private/templates/swarm.statefulset.yaml
@@ -68,7 +68,7 @@ spec:
           --metrics.influxdb.username={{ .Values.influxdb.setDefaultUser.user.username }}
           --metrics.influxdb.password={{ .Values.influxdb.setDefaultUser.user.password }}
           --metrics.influxdb.database=metrics
-          --metrics.influxdb.host.tag=$(POD_NAME)
+          --metrics.influxdb.tags="host=$(POD_NAME)"
       {{- end }}
       {{- if .Values.swarm.tracingEnabled }}
           --tracing

--- a/swarm/Chart.yaml
+++ b/swarm/Chart.yaml
@@ -1,5 +1,5 @@
 name: swarm
-version: 0.0.1
+version: 0.0.2
 description: Create an ethereum swarm cluster
 keywords:
 - ethereum

--- a/swarm/templates/swarm.statefulset.yaml
+++ b/swarm/templates/swarm.statefulset.yaml
@@ -85,7 +85,7 @@ spec:
           --metrics.influxdb.username={{ .Values.influxdb.setDefaultUser.user.username }}
           --metrics.influxdb.password={{ .Values.influxdb.setDefaultUser.user.password }}
           --metrics.influxdb.database=metrics
-          --metrics.influxdb.host.tag=$(POD_NAME)
+          --metrics.influxdb.tags="host=$(POD_NAME)"
           {{- end }}
           {{- if .Values.swarm.tracingEnabled }}
           --tracing


### PR DESCRIPTION
This is incompatible with older versions of swarm. Therefore bumping the chart version so that we can still use version 0.0.1 of the chart to test the older binaries.