### PR TITLE
swarm: use bzzkey and pubkey as influxdb tags

### DIFF
--- a/swarm-private/templates/swarm.statefulset.yaml
+++ b/swarm-private/templates/swarm.statefulset.yaml
@@ -44,6 +44,10 @@ spec:
         - -ac
         - >
           export BOOTNODE_IP=$(nslookup {{ template "swarm.fullname" . }}-bootnode | grep Address | awk '{ print $3 }') &&
+        {{- if .Values.swarm.metricsEnabled }}
+          export BZZKEY=$(sh /run.sh print-keys | grep bzzkey=    | cut -d '=' -f2 | cut -c1-7) &&
+          export PUBKEY=$(sh /run.sh print-keys | grep publicKey= | cut -d '=' -f2 | cut -c1-10) &&
+        {{- end }}
           /run.sh
           --ens-api={{ .Values.swarm.config.ens_api }}
           --port=30399
@@ -68,7 +72,7 @@ spec:
           --metrics.influxdb.username={{ .Values.influxdb.setDefaultUser.user.username }}
           --metrics.influxdb.password={{ .Values.influxdb.setDefaultUser.user.password }}
           --metrics.influxdb.database=metrics
-          --metrics.influxdb.tags="host=$(POD_NAME)"
+          --metrics.influxdb.tags="host=$(POD_NAME),bzzkey=$BZZKEY,pubkey=$PUBKEY"
       {{- end }}
       {{- if .Values.swarm.tracingEnabled }}
           --tracing

--- a/swarm/templates/swarm.statefulset.yaml
+++ b/swarm/templates/swarm.statefulset.yaml
@@ -59,6 +59,10 @@ spec:
         - -ac
         - >
           source /env/swarm.env;
+        {{- if .Values.swarm.metricsEnabled }}
+          export BZZKEY=$(sh /run.sh print-keys | grep bzzkey=    | cut -d '=' -f2 | cut -c1-7) &&
+          export PUBKEY=$(sh /run.sh print-keys | grep publicKey= | cut -d '=' -f2 | cut -c1-10) &&
+        {{- end }}
           /run.sh
           --ens-api={{ .Values.swarm.config.ens_api }}
           --port=$NODEPORT
@@ -85,7 +89,7 @@ spec:
           --metrics.influxdb.username={{ .Values.influxdb.setDefaultUser.user.username }}
           --metrics.influxdb.password={{ .Values.influxdb.setDefaultUser.user.password }}
           --metrics.influxdb.database=metrics
-          --metrics.influxdb.tags="host=$(POD_NAME)"
+          --metrics.influxdb.tags="host=$(POD_NAME),bzzkey=$BZZKEY,pubkey=$PUBKEY"
           {{- end }}
           {{- if .Values.swarm.tracingEnabled }}
           --tracing


### PR DESCRIPTION
Note that I'm only using the 7 first bytes of the bzzkey and 10 first bytes of the pubkey. 

I'm happy to change this if desired. 