### PR TITLE
smoke: use new docker repo

### DIFF
--- a/smoke/values.yaml
+++ b/smoke/values.yaml
@@ -5,7 +5,7 @@
 smoke:
   # Image configuration
   image:
-    repository: ethdevops/swarm
+    repository: ethdevops/swarm-smoke
     tag: edge
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'


### PR DESCRIPTION
Related to https://github.com/ethersphere/go-ethereum/issues/1202

Image split PR: https://github.com/ethereum/go-ethereum/pull/19038