### PR TITLE
Add global-store chart

### DIFF
--- a/swarm-global-store/.helmignore
+++ b/swarm-global-store/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/swarm-global-store/Chart.yaml
+++ b/swarm-global-store/Chart.yaml
@@ -1,0 +1,19 @@
+name: swarm-global-store
+version: 0.0.1
+description: A global store that can be used by Swarm nodes to persist their data. Mainly used for debugging and testing purposes.
+keywords:
+- ethereum
+- blockchain
+- swarm
+- storage
+- web3
+home: https://swarm.ethereum.org
+sources:
+- https://github.com/ethereum/go-ethereum
+- https://github.com/ethereum/go-ethereum/tree/master/swarm
+- https://github.com/ethereum/go-ethereum/tree/master/cmd/swarm/global-store
+maintainers:
+- name: skylenet
+  email: rafael@ethereum.org
+icon: https://swarm-guide.readthedocs.io/en/latest/_images/swarm.png
+appVersion: dev

--- a/swarm-global-store/README.md
+++ b/swarm-global-store/README.md
@@ -1,0 +1,5 @@
+# swarm-global-store
+
+This chart deploys a [global-store](https://github.com/ethereum/go-ethereum/tree/master/cmd/swarm/global-store) that can be used by Swarm nodes to store their data at a central place. This is mainly useful for debugging and testing purposes. By default it will run in-memory, you can also choose to persist data to disk. See [values.yaml](values.yaml) for more details.
+
+Swarm nodes that want to use this globalstore should run with the `--globalstore-api ` flag . E.g.: `--globalstore-api=ws://swarm-global-store:3033`

--- a/swarm-global-store/templates/_helpers.tpl
+++ b/swarm-global-store/templates/_helpers.tpl
@@ -1,0 +1,36 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "globalstore.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "globalstore.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- if contains .Release.Name $name -}}
+{{- $name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "globalstore.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/swarm-global-store/templates/globalstore.service.yaml
+++ b/swarm-global-store/templates/globalstore.service.yaml
@@ -1,0 +1,19 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: {{ template "globalstore.fullname" . }}
+  labels:
+    app: {{ template "globalstore.name" . }}
+    chart: {{ template "globalstore.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    component: global-store
+spec:
+  selector:
+    app: {{ template "globalstore.name" . }}
+    release: {{ .Release.Name }}
+    component: global-store
+  clusterIP: None
+  ports:
+  - name: network
+    port: 3033

--- a/swarm-global-store/templates/globalstore.statefulset.yaml
+++ b/swarm-global-store/templates/globalstore.statefulset.yaml
@@ -1,0 +1,83 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ template "globalstore.fullname" . }}
+  labels:
+    app: {{ template "globalstore.name" . }}
+    chart: {{ template "globalstore.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    component: global-store
+spec:
+  serviceName: {{ template "globalstore.fullname" . }}
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {{ template "globalstore.name" . }}
+      release: {{ .Release.Name }}
+      component: global-store
+  template:
+    metadata:
+      labels:
+        app: {{ template "globalstore.name" . }}
+        release: {{ .Release.Name }}
+        component: global-store
+    spec:
+      containers:
+      - name: global-store
+        image: {{ .Values.globalstore.image.repository }}:{{ .Values.globalstore.image.tag }}
+        imagePullPolicy: {{ .Values.globalstore.imagePullPolicy }}
+        resources:
+{{ toYaml .Values.globalstore.resources | indent 10 }}
+        args:
+        - websocket
+{{- if .Values.globalstore.persistence.diskEnabled }}
+        - --dir=/data
+{{- end }}
+{{- range $i, $flag := .Values.globalstore.config.extraFlags }}
+        - {{ $flag }}
+{{- end }}
+        ports:
+        - name: globalstore
+          containerPort: 3033
+        volumeMounts:
+        - name: data
+          mountPath: /data
+      volumes:
+{{- if not .Values.globalstore.persistence.pvc.enabled }}
+      - name: data
+        emptyDir: {}
+{{- else }}
+  volumeClaimTemplates:
+  - metadata:
+      name: data
+      labels:
+        app: {{ template "globalstore.name" . }}
+        release: "{{ .Release.Name }}"
+        heritage: "{{ .Release.Service }}"
+    spec:
+      accessModes:
+        - {{ .Values.globalstore.persistence.pvc.accessMode | quote }}
+      resources:
+          requests:
+            storage: {{ .Values.globalstore.persistence.pvc.size | quote }}
+  {{- if .Values.globalstore.persistence.pvc.storageClass }}
+    {{- if (eq "-" .Values.globalstore.persistence.pvc.storageClass) }}
+      storageClassName: ""
+    {{- else }}
+      storageClassName: "{{ .Values.globalstore.persistence.pvc.storageClass }}"
+    {{- end }}
+  {{- end }}
+{{- end }}
+{{- with .Values.globalstore.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+{{- end }}
+{{- with .Values.globalstore.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+{{- end }}
+{{- with .Values.globalstore.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+{{- end }}

--- a/swarm-global-store/values.yaml
+++ b/swarm-global-store/values.yaml
@@ -1,0 +1,41 @@
+# Default values for swarm.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+globalstore:
+  # Image configuration
+  image:
+    repository: ethdevops/swarm-global-store
+    tag: edge
+  ## Specify a imagePullPolicy
+  ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
+  ##
+  imagePullPolicy: Always
+  config:
+    extraFlags:
+    - "--verbosity=3"
+  persistence:
+    ## Enable storage to be on disk. When not enabled, the global-store will persist data in-memory (RAM)
+    diskEnabled: false
+    pvc:
+      ## Create a PVC to use for disk storage
+      enabled: false
+      ## Persistent Volume Storage Class
+      ## If defined, storageClassName: <storageClass>
+      ## If set to "-", storageClassName: "", which disables dynamic provisioning
+      ## If undefined (the default) or set to null, no storageClassName spec is
+      ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
+      ##   GKE, AWS & OpenStack)
+      ##
+      # storageClass: "-"
+      accessMode: ReadWriteOnce
+      size: 8Gi
+  ## Configure resource requests and limits
+  ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
+  resources: {}
+  ## Node labels and tolerations for pod assignment
+  ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
+  ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#taints-and-tolerations-beta-feature
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}


### PR DESCRIPTION
This chart deploys a [global-store](https://github.com/ethereum/go-ethereum/tree/master/cmd/swarm/global-store) that can be used by Swarm nodes to store their data at a central place. This is mainly useful for debugging and testing purposes. By default it will run in-memory, you can also choose to persist data to disk. See values.yaml for more details.

Swarm nodes that want to use this globalstore should run with the `--globalstore-api ` flag . E.g.: `--globalstore-api=ws://swarm-global-store:3033`
