### PR TITLE
Add chart that periodically runs tests against the swarm codebase

### DIFF
--- a/swarm-tests/.helmignore
+++ b/swarm-tests/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/swarm-tests/Chart.yaml
+++ b/swarm-tests/Chart.yaml
@@ -1,0 +1,18 @@
+name: swarm-tests
+version: 0.0.1
+description: Execute tests against the swarm codebase
+keywords:
+- ethereum
+- blockchain
+- swarm
+- storage
+- web3
+home: https://swarm.ethereum.org
+sources:
+- https://github.com/ethereum/go-ethereum
+- https://github.com/ethereum/go-ethereum/tree/master/swarm
+maintainers:
+- name: skylenet
+  email: rafael@ethereum.org
+icon: https://swarm-guide.readthedocs.io/en/latest/_images/swarm.png
+appVersion: dev

--- a/swarm-tests/README.md
+++ b/swarm-tests/README.md
@@ -1,0 +1,16 @@
+# swarm-test
+
+This chart is used to execute go tests against the swarm codebase.
+
+A cronjob will be created and will fetch whatever version you define and execute tests against the codebase.
+
+Have a look at the [`values.yaml`](values.yaml) file to check the default values. You can easily set the version and the command that you want to use for testing. See the example below:
+
+```yaml
+test:
+  config:
+    # Version to be used (branch, commit hash, tag)
+    version: master
+    # Test command to execute
+    command: go test -v ./swarm/... -longrunning true
+```

--- a/swarm-tests/scripts/run-tests.sh
+++ b/swarm-tests/scripts/run-tests.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+set -xe
+
+VERSION="${VERSION:-master}"
+
+apk add --update git gcc g++ linux-headers
+
+mkdir -p "$GOPATH/src/github.com/ethereum"
+cd "$GOPATH/src/github.com/ethereum"
+git clone https://github.com/ethersphere/go-ethereum
+cd "$GOPATH/src/github.com/ethereum/go-ethereum"
+git checkout "$VERSION"
+
+$@

--- a/swarm-tests/scripts/run-tests.sh
+++ b/swarm-tests/scripts/run-tests.sh
@@ -11,4 +11,4 @@ git clone https://github.com/ethersphere/go-ethereum
 cd "$GOPATH/src/github.com/ethereum/go-ethereum"
 git checkout "$VERSION"
 
-$@
+sh -c "$@"

--- a/swarm-tests/templates/_helpers.tpl
+++ b/swarm-tests/templates/_helpers.tpl
@@ -1,0 +1,36 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "test.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "test.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- if contains .Release.Name $name -}}
+{{- $name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "test.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/swarm-tests/templates/scripts.configmap.yaml
+++ b/swarm-tests/templates/scripts.configmap.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "test.fullname" . }}-scripts
+  labels:
+    app: {{ template "test.name" . }}
+    chart: {{ template "test.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+data:
+{{ (.Files.Glob "scripts/*").AsConfig | indent 2 }}

--- a/swarm-tests/templates/tests.cronjob.yaml
+++ b/swarm-tests/templates/tests.cronjob.yaml
@@ -15,8 +15,18 @@ spec:
   failedJobsHistoryLimit: {{ $root.Values.test.failedJobsHistoryLimit }}
   concurrencyPolicy: {{ $root.Values.test.concurrencyPolicy | quote }}
   jobTemplate:
+    metadata:
+      labels:
+        app: {{ template "test.name" $root }}
+        chart: {{ template "test.chart" . }}
+        release: {{ .Release.Name }}
     spec:
       template:
+        metadata:
+          labels:
+            app: {{ template "test.name" $root }}
+            chart: {{ template "test.chart" . }}
+            release: {{ .Release.Name }}
         spec:
           containers:
           - name: test

--- a/swarm-tests/templates/tests.cronjob.yaml
+++ b/swarm-tests/templates/tests.cronjob.yaml
@@ -1,0 +1,40 @@
+{{- $root := . -}}
+
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: {{ template "test.fullname" $root }}
+  labels:
+    app: {{ template "test.name" $root }}
+    chart: {{ template "test.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  schedule: "{{ $root.Values.test.schedule }}"
+  successfulJobsHistoryLimit: {{ $root.Values.test.successfulJobsHistoryLimit }}
+  failedJobsHistoryLimit: {{ $root.Values.test.failedJobsHistoryLimit }}
+  concurrencyPolicy: {{ $root.Values.test.concurrencyPolicy | quote }}
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: test
+            image: {{ .Values.test.image.repository }}:{{ .Values.test.image.tag }}
+            imagePullPolicy: {{ .Values.test.imagePullPolicy | quote }}
+            env:
+            - name: VERSION
+              value: {{ .Values.test.config.version | quote}}
+            resources:
+{{ toYaml .Values.test.resources | indent 14 }}
+            command: ["sh", "/scripts/run-tests.sh"]
+            args:
+            - {{ .Values.test.config.command | quote}}
+            volumeMounts:
+            - name: scripts
+              mountPath: /scripts
+          restartPolicy: Never
+          volumes:
+          - name: scripts
+            configMap:
+              name: {{ template "test.fullname" . }}-scripts

--- a/swarm-tests/values.yaml
+++ b/swarm-tests/values.yaml
@@ -1,0 +1,39 @@
+# Default values for swarm.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+test:
+  # Image configuration
+  image:
+    repository: golang
+    tag: 1.11-alpine
+  ## Specify a imagePullPolicy
+  ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
+  ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
+  ##
+  imagePullPolicy: IfNotPresent
+  # Schedule is a cron format string that defines when a job is to be created and executed.
+  # https://en.wikipedia.org/wiki/Cron
+  # The default is every 6 hours
+  schedule: "0 */6 * * *"
+  # concurrencyPolicy can be "Allow", "Forbid" or "Replace"
+  # https://kubernetes.io/docs/tasks/job/automated-tasks-with-cron-jobs/#concurrency-policy
+  concurrencyPolicy: Forbid
+  # How many successfull jobs we should keep
+  successfulJobsHistoryLimit: 3
+  # How many failed jobs we should keep
+  failedJobsHistoryLimit: 3
+  config:
+    # Version to be used (branch, commit hash, tag)
+    version: master
+    # Test command to execute
+    command: go test -v ./swarm/... -longrunning true
+  ## Configure resource requests and limits
+  ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
+  resources:
+    requests:
+      memory: 10Gi
+      cpu: 2.0
+    limits:
+      memory: 10Gi
+      cpu: 3.0


### PR DESCRIPTION
Issue: https://github.com/ethersphere/go-ethereum/issues/1236

This chart is used to execute go tests against the swarm codebase.

A cronjob will be created and will fetch whatever version you define and execute tests against the codebase.

Have a look at the `values.yaml` file to check the default values. You can easily set the version and the command that you want to use for testing. See the example below:

```yaml
test:
  config:
    # Version to be used (branch, commit hash, tag)
    version: master
    # Test command to execute
    command: go test -v ./swarm/... -longrunning true
```
