### PR TITLE
swarm: allow exposing websocket rpc api for testing purposes

### DIFF
--- a/swarm-private/templates/swarm.ingress.yaml
+++ b/swarm-private/templates/swarm.ingress.yaml
@@ -60,5 +60,11 @@ spec:
         backend:
           serviceName: {{ template "swarm.fullname" $root }}-internal-{{ $i }}
           servicePort: 8500
+    {{- if $root.Values.swarm.ingress.exposeWebsocketRPC }}
+      - path: /wsrpc
+        backend:
+          serviceName: {{ template "swarm.fullname" $root }}-internal-{{ $i }}
+          servicePort: 8546
+    {{- end }}
 {{- end }}
 {{- end }}

--- a/swarm-private/templates/swarm.service.yaml
+++ b/swarm-private/templates/swarm.service.yaml
@@ -44,6 +44,9 @@ spec:
   ports:
   - name: http-interface
     port: 8500
+  {{- if $root.Values.swarm.ingress.exposeWebsocketRPC }}
+  - name: ws-rpc
+    port: 8546
+  {{- end }}
 
 {{- end }}
-

--- a/swarm-private/values.yaml
+++ b/swarm-private/values.yaml
@@ -107,6 +107,9 @@ swarm:
 
   ingress:
     enabled: true
+    # Warning: Exposing the websocket RPC API can be dangerous.
+    #          This should be used only for testing purposes.
+    exposeWebsocketRPC: false
     tls:
       enabled: false
       acmeEnabled: false # Use cert-manager to generate certificates via ACME

--- a/swarm/templates/swarm.ingress.yaml
+++ b/swarm/templates/swarm.ingress.yaml
@@ -60,5 +60,11 @@ spec:
         backend:
           serviceName: {{ template "swarm.fullname" $root }}-internal-{{ $i }}
           servicePort: 8500
+    {{- if $root.Values.swarm.ingress.exposeWebsocketRPC }}
+      - path: /wsrpc
+        backend:
+          serviceName: {{ template "swarm.fullname" $root }}-internal-{{ $i }}
+          servicePort: 8546
+    {{- end }}
 {{- end }}
 {{- end }}

--- a/swarm/templates/swarm.service.yaml
+++ b/swarm/templates/swarm.service.yaml
@@ -69,5 +69,9 @@ spec:
   ports:
   - name: http-interface
     port: 8500
+  {{- if $root.Values.swarm.ingress.exposeWebsocketRPC }}
+  - name: ws-rpc
+    port: 8546
+  {{- end }}
 
 {{- end }}

--- a/swarm/values.yaml
+++ b/swarm/values.yaml
@@ -216,6 +216,9 @@ influxdb:
 
   ingress:
     enabled: false
+    # Warning: Exposing the websocket RPC API can be dangerous.
+    #          This should be used only for testing purposes.
+    exposeWebsocketRPC: false
     tls: false
     # secretName: my-tls-cert # only needed if tls above is true
     hostname: influxdb.foobar.com


### PR DESCRIPTION
Requested via https://github.com/ethersphere/go-ethereum/issues/1220 

When enabled, your ingress resources targeting individual nodes, will have the websocket RPC API accessible via `/wsrpc`

Example of a request targeting a swarm node: 

```
echo '{"jsonrpc":"2.0","method":"admin_peers","id":1}' | websocat wss://swarm-private-0-yournamespace.stg.swarm-gateways.net/wsrpc --origin localhost
```

Example `values.yaml` file that enables the ws APIs and exposes them at the ingress level.

```yaml
swarm:
  metricsEnabled: true
  tracingEnabled: true
  profilingEnabled: false
  image:
    repository: ethdevops/swarm
    tag: edge
  terminationGracePeriodSeconds: 5
  imagePullPolicy: IfNotPresent
  podManagementPolicy: Parallel
  updateStrategy:
    type: "OnDelete"
  config:
    ens_api: http://mainnet-geth-geth.geth:8545
    verbosity: 4
    debug: true
    maxpeers: 25
    bzznetworkid: 3
    extraFlags:
      - --ws
      - --wsaddr=0.0.0.0
      - --wsorigins=localhost
      - --wsapi=admin,net,debug
  ingress:
    domain: stg.swarm-gateways.net
    enabled: true
    # Warning: Exposing the websocket RPC API can be dangerous.
    #          This should be used only for testing purposes.
    exposeWebsocketRPC: true
    tls:
      enabled: true
      acmeEnabled: false
    annotations:
      nginx.ingress.kubernetes.io/proxy-body-size: 500m
      nginx.ingress.kubernetes.io/ssl-redirect: "false"
  persistence:
    enabled: false
  resources:
    requests:
      memory: 512Mi
      cpu: 0.1
    limits:
      memory: 1024Mi
      cpu: 0.3
```