### PR TITLE
jaeger-query: don't expose query service with NodePort

### DIFF
--- a/swarm-private/values.yaml
+++ b/swarm-private/values.yaml
@@ -130,7 +130,7 @@ jaeger:
   replicaCount: 1
   service:
     query:
-      type: NodePort
+      type: ClusterIP
     agent:
       type: ClusterIP
   ## Configure resource requests and limits
@@ -157,7 +157,6 @@ influxdb:
     pullPolicy: IfNotPresent
 
   ## Specify a service type
-  ## NodePort is default
   ## ref: http://kubernetes.io/docs/user-guide/services/
   ##
   service:

--- a/swarm/values.yaml
+++ b/swarm/values.yaml
@@ -107,7 +107,7 @@ jaeger:
   replicaCount: 1
   service:
     query:
-      type: NodePort
+      type: ClusterIP
     agent:
       type: ClusterIP
   ## Configure resource requests and limits
@@ -134,7 +134,6 @@ influxdb:
     pullPolicy: IfNotPresent
 
   ## Specify a service type
-  ## NodePort is default
   ## ref: http://kubernetes.io/docs/user-guide/services/
   ##
   service:


### PR DESCRIPTION
Currently when running with tracing enabled, the Jaeger Query service is being exposed via `NodePort` by default. This should not be the case. 