### PR TITLE
Swarm: pod annotations

### DIFF
--- a/swarm-private/templates/bootnode.statefulset.yaml
+++ b/swarm-private/templates/bootnode.statefulset.yaml
@@ -22,6 +22,10 @@ spec:
         app: {{ template "swarm.name" . }}
         release: {{ .Release.Name }}
         component: bootnode
+        {{- if .Values.bootnode.podAnnotations }}
+      annotations:
+{{ toYaml .Values.bootnode.podAnnotations | indent 8 }}
+        {{- end }}
     spec:
       containers:
       - name: bootnode

--- a/swarm-private/templates/bootnode.statefulset.yaml
+++ b/swarm-private/templates/bootnode.statefulset.yaml
@@ -22,12 +22,6 @@ spec:
         app: {{ template "swarm.name" . }}
         release: {{ .Release.Name }}
         component: bootnode
-    {{- if or (eq .Values.bootnode.image.tag "latest") (eq .Values.bootnode.image.tag "edge") }}
-      annotations:
-        # Note: 'latest' or 'edge' tag is beeing used, therefore we keep changing
-        # this annotation to force a redeployment of the pods within the StatefulSet
-        "release-timestamp": {{.Release.Time.Seconds | quote }}
-    {{- end }}
     spec:
       containers:
       - name: bootnode

--- a/swarm-private/templates/swarm.statefulset.yaml
+++ b/swarm-private/templates/swarm.statefulset.yaml
@@ -25,6 +25,10 @@ spec:
         app: {{ template "swarm.name" . }}
         release: {{ .Release.Name }}
         component: swarm
+        {{- if .Values.swarm.podAnnotations }}
+      annotations:
+{{ toYaml .Values.swarm.podAnnotations | indent 8 }}
+        {{- end }}
     spec:
       terminationGracePeriodSeconds: {{ .Values.swarm.terminationGracePeriodSeconds }}
       containers:

--- a/swarm-private/templates/swarm.statefulset.yaml
+++ b/swarm-private/templates/swarm.statefulset.yaml
@@ -25,12 +25,6 @@ spec:
         app: {{ template "swarm.name" . }}
         release: {{ .Release.Name }}
         component: swarm
-    {{- if or (eq .Values.swarm.image.tag "latest") (eq .Values.swarm.image.tag "edge") }}
-      annotations:
-        # Note: 'latest' or 'edge' tag is beeing used, therefore we keep changing
-        # this annotation to force a redeployment of the pods within the StatefulSet
-        "release-timestamp": {{.Release.Time.Seconds | quote }}
-    {{- end }}
     spec:
       terminationGracePeriodSeconds: {{ .Values.swarm.terminationGracePeriodSeconds }}
       containers:

--- a/swarm-private/values.yaml
+++ b/swarm-private/values.yaml
@@ -12,6 +12,9 @@ bootnode:
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
   ##
   imagePullPolicy: Always
+  ## (dict) If specified, apply these annotations to the bootnode pod
+  # podAnnotations:
+  #   fluentbit.io/exclude: "true"
   config:
     verbosity: 3
     publicaddr: 846c424961adc146d54861bdf1eb6015e6908b689fd12d01c61307fffc848c22e514f5c898dc9243fbb17aa80750b556772599d84fe86a4b715f40ebc4c049bf
@@ -44,6 +47,9 @@ swarm:
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
   ##
   imagePullPolicy: Always
+  ## (dict) If specified, apply these annotations to the swarm pods
+  # podAnnotations:
+  #   fluentbit.io/exclude: "true"
   # How many swarm nodes we want to run
   replicaCount: 0
   # Pod management policy

--- a/swarm/templates/swarm.statefulset.yaml
+++ b/swarm/templates/swarm.statefulset.yaml
@@ -25,12 +25,6 @@ spec:
         app: {{ template "swarm.name" . }}
         release: {{ .Release.Name }}
         component: swarm
-    {{- if or (eq .Values.swarm.image.tag "latest") (eq .Values.swarm.image.tag "edge") }}
-      annotations:
-        # Note: 'latest' or 'edge' tag is beeing used, therefore we keep changing
-        # this annotation to force a redeployment of the pods within the StatefulSet
-        "release-timestamp": {{.Release.Time.Seconds | quote }}
-    {{- end }}
     spec:
       serviceAccountName: {{ template "swarm.fullname" . }}
       terminationGracePeriodSeconds: {{ .Values.swarm.terminationGracePeriodSeconds }}

--- a/swarm/templates/swarm.statefulset.yaml
+++ b/swarm/templates/swarm.statefulset.yaml
@@ -25,6 +25,10 @@ spec:
         app: {{ template "swarm.name" . }}
         release: {{ .Release.Name }}
         component: swarm
+        {{- if .Values.swarm.podAnnotations }}
+      annotations:
+{{ toYaml .Values.swarm.podAnnotations | indent 8 }}
+        {{- end }}
     spec:
       serviceAccountName: {{ template "swarm.fullname" . }}
       terminationGracePeriodSeconds: {{ .Values.swarm.terminationGracePeriodSeconds }}

--- a/swarm/values.yaml
+++ b/swarm/values.yaml
@@ -19,6 +19,9 @@ swarm:
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
   ##
   imagePullPolicy: Always
+  ## (dict) If specified, apply these annotations to the swarm pods
+  # podAnnotations:
+  #   fluentbit.io/exclude: "true"
   # How many swarm nodes we want to run
   replicaCount: 2
   # Pod management policy


### PR DESCRIPTION
I've removed the "release-timestamp" annotation. I've changed my mind and this shouldn't be done like this.

If a client want's to trigger a deployment, this can be done by using the image hash or by updating a custom annotation.

This also brings the benefit of allowing us to use custom annotations on our pods. For example `fluentbit.io/exclude: "true"` would disable log forwarding to elasticsearch.