### PR TITLE
add kapacitor script importer

### DIFF
--- a/kapacitor-importer/.helmignore
+++ b/kapacitor-importer/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/kapacitor-importer/Chart.yaml
+++ b/kapacitor-importer/Chart.yaml
@@ -1,0 +1,13 @@
+name: kapacitor-importer
+version: 0.0.1
+description: Used to import .tick scripts to an existing kapacitor instance
+keywords:
+- kapacitor
+- alerting
+home: https://docs.influxdata.com/kapacitor/
+sources:
+- https://github.com/influxdata/kapacitor
+maintainers:
+- name: skylenet
+  email: rafael@ethereum.org
+appVersion: dev

--- a/kapacitor-importer/README.md
+++ b/kapacitor-importer/README.md
@@ -1,6 +1,6 @@
 # kapacitor-importer
 
-This chart is used to run a job that imports batch or stream .tick scripts into an exising kapacitor instance.
+This chart is used to run a job that imports batch or stream .tick scripts into an existing kapacitor instance.
 
 
 For more information, check the default [`values.yaml`](values.yaml). You need to overwrite the `kapacitorURL` to point to your kapacitor service.

--- a/kapacitor-importer/README.md
+++ b/kapacitor-importer/README.md
@@ -1,0 +1,32 @@
+# kapacitor-importer
+
+This chart is used to run a job that imports batch or stream .tick scripts into an exising kapacitor instance.
+
+
+For more information, check the default [`values.yaml`](values.yaml). You need to overwrite the `kapacitorURL` to point to your kapacitor service.
+
+
+The following is an example on how you can create your own batch script:
+
+```yaml
+
+# Set the address to your kapacitor service
+kapacitorUrl: http://your-kapacitor-service:9092
+
+# Add custom batch scripts. Note: They must end with .tick
+batchScripts:
+ # Example CPU Alert
+ cpu_alert.tick: |-
+   dbrp "telegraf"."autogen"
+   batch
+       |query('''
+           SELECT mean(usage_idle)
+           FROM "telegraf"."autogen"."cpu"
+       ''')
+           .period(5m)
+           .every(5m)
+           .groupBy(time(1m), 'cpu')
+       |alert()
+           .crit(lambda: "mean" < 70)
+           .log('/tmp/batch_alerts.log')
+```

--- a/kapacitor-importer/templates/_helpers.tpl
+++ b/kapacitor-importer/templates/_helpers.tpl
@@ -1,0 +1,36 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "kapacitorImporter.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "kapacitorImporter.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- if contains .Release.Name $name -}}
+{{- $name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "kapacitorImporter.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/kapacitor-importer/templates/configmap.batchscripts.yaml
+++ b/kapacitor-importer/templates/configmap.batchscripts.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "kapacitorImporter.fullname" . }}-batchscripts
+  labels:
+    app: {{ template "kapacitorImporter.name" . }}
+    chart: {{ template "kapacitorImporter.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+data:
+  "README.txt": "This directory should contain .tick batch scripts"
+{{- if  .Values.batchScripts }}
+{{ toYaml .Values.batchScripts | indent 2 }}
+{{- end }}

--- a/kapacitor-importer/templates/configmap.init.yaml
+++ b/kapacitor-importer/templates/configmap.init.yaml
@@ -1,0 +1,45 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "kapacitorImporter.fullname" . }}-init
+  labels:
+    app: {{ template "kapacitorImporter.name" . }}
+    chart: {{ template "kapacitorImporter.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+data:
+  init.sh: |-
+    #!/usr/bin/env bash
+    set -xe
+
+    echo "Waiting kapacitor to launch on 8080..."
+
+    while ! kapacitor stats general; do
+      sleep 1
+    done
+
+    echo "Kapacitor launched"
+    sleep 5
+
+    kapacitor list tasks
+{{- if  .Values.batchScripts }}
+    ls -la /scripts-batch
+    for f in /scripts-batch/*.tick
+    do
+      name="$(basename $f)"
+      name="${name/.tick/}"
+      kapacitor define batch_$name -type batch -tick $f
+      kapacitor enable batch_$name
+    done
+{{- end }}
+{{- if  .Values.streamScripts }}
+    ls -la /scripts-stream
+    for f in /scripts-stream/*.tick
+    do
+      name="$(basename $f)"
+      name="${name/.tick/}"
+      kapacitor define stream_$name -type stream -tick $f
+      kapacitor enable stream_$name
+    done
+{{- end }}
+    kapacitor list tasks

--- a/kapacitor-importer/templates/configmap.streamscripts.yaml
+++ b/kapacitor-importer/templates/configmap.streamscripts.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "kapacitorImporter.fullname" . }}-streamscripts
+  labels:
+    app: {{ template "kapacitorImporter.name" . }}
+    chart: {{ template "kapacitorImporter.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+data:
+  "README.txt": "This directory should contain .tick stream scripts"
+{{- if  .Values.streamScripts }}
+{{ toYaml .Values.streamScripts | indent 2 }}
+{{- end }}

--- a/kapacitor-importer/templates/job.yaml
+++ b/kapacitor-importer/templates/job.yaml
@@ -1,0 +1,48 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ template "kapacitorImporter.fullname" . }}
+  labels:
+    app: {{ template "kapacitorImporter.name" . }}
+    chart: {{ template "kapacitorImporter.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  template:
+    metadata:
+      name: "{{.Release.Name}}"
+      labels:
+        heritage: {{.Release.Service | quote }}
+        release: {{.Release.Name | quote }}
+        chart: "{{.Chart.Name}}-{{.Chart.Version}}"
+      annotations:
+        checksum/init-config: {{ include (print $.Template.BasePath "/configmap.init.yaml") . | sha256sum }}
+        checksum/batch-config: {{ include (print $.Template.BasePath "/configmap.batchscripts.yaml") . | sha256sum }}
+        checksum/stream-config: {{ include (print $.Template.BasePath "/configmap.streamscripts.yaml") . | sha256sum }}
+    spec:
+      restartPolicy: OnFailure
+      containers:
+      - name: kapacitor-importer
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        command: ["bash", "/init/init.sh"]
+        env:
+          - name: KAPACITOR_URL
+            value: "{{ .Values.kapacitorURL }}"
+        volumeMounts:
+        - name: init
+          mountPath: /init
+        - name: batchscripts
+          mountPath: /scripts-batch
+        - name: streamscripts
+          mountPath: /scripts-stream
+      volumes:
+      - name: batchscripts
+        configMap:
+          name: {{ template "kapacitorImporter.fullname" . }}-batchscripts
+      - name: streamscripts
+        configMap:
+          name: {{ template "kapacitorImporter.fullname" . }}-streamscripts
+      - name: init
+        configMap:
+          name: {{ template "kapacitorImporter.fullname" . }}-init

--- a/kapacitor-importer/values.yaml
+++ b/kapacitor-importer/values.yaml
@@ -1,0 +1,24 @@
+image:
+  repository: "kapacitor"
+  tag: "1.4"
+  pullPolicy: "IfNotPresent"
+
+kapacitorURL: http://kapacitor:9092
+
+# batchScripts:
+#  # Example script
+#  cpu_alert.tick: |-
+#    dbrp "telegraf"."autogen"
+#    batch
+#        |query('''
+#            SELECT mean(usage_idle)
+#            FROM "telegraf"."autogen"."cpu"
+#        ''')
+#            .period(5m)
+#            .every(5m)
+#            .groupBy(time(1m), 'cpu')
+#        |alert()
+#            .crit(lambda: "mean" < 70)
+#            .log('/tmp/batch_alerts.log')
+
+# streamScripts:


### PR DESCRIPTION
**This is a pre-requirement for setting up alerts on our swarm metrics** : https://github.com/ethersphere/go-ethereum/issues/1251 

## kapacitor-importer

This chart is used to run a job that imports batch or stream .tick scripts into an exising kapacitor instance.


For more information, check the default [`values.yaml`](values.yaml). You need to overwrite the `kapacitorURL` to point to your kapacitor service.


The following is an example on how you can create your own batch script:

```yaml

# Set the address to your kapacitor service
kapacitorUrl: http://your-kapacitor-service:9092

# Add custom batch scripts. Note: They must end with .tick
batchScripts:
 # Example CPU Alert
 cpu_alert.tick: |-
   dbrp "telegraf"."autogen"
   batch
       |query('''
           SELECT mean(usage_idle)
           FROM "telegraf"."autogen"."cpu"
       ''')
           .period(5m)
           .every(5m)
           .groupBy(time(1m), 'cpu')
       |alert()
           .crit(lambda: "mean" < 70)
           .log('/tmp/batch_alerts.log')
```