### PR TITLE
swarm-private: fix bootnode port to be the same as on swarm nodes

### DIFF
--- a/swarm-private/templates/bootnode.service-headless.yaml
+++ b/swarm-private/templates/bootnode.service-headless.yaml
@@ -16,4 +16,4 @@ spec:
   clusterIP: None
   ports:
   - name: network
-    port: 30301
+    port: 30399

--- a/swarm-private/templates/bootnode.statefulset.yaml
+++ b/swarm-private/templates/bootnode.statefulset.yaml
@@ -44,7 +44,7 @@ spec:
           --verbosity={{ .Values.bootnode.config.verbosity }}
           --maxpeers=5000
           --nat=ip:$POD_IP
-          --port=30301
+          --port=30399
           --bzznetworkid={{ .Values.swarm.config.bzznetworkid }}
           --bootnodes=""
 {{- range $i, $flag := .Values.bootnode.config.extraFlags }}
@@ -66,7 +66,7 @@ spec:
               key: PASSWORD
         ports:
         - name: network
-          containerPort: 30301
+          containerPort: 30399
         volumeMounts:
         - name: keys
           mountPath: /keys

--- a/swarm-private/templates/swarm.statefulset.yaml
+++ b/swarm-private/templates/swarm.statefulset.yaml
@@ -59,7 +59,7 @@ spec:
           --maxpeers={{ .Values.swarm.config.maxpeers }}
           --ipcpath=bzzd.ipc
           --bzznetworkid={{ .Values.swarm.config.bzznetworkid }}
-          --bootnodes=enode://{{ .Values.bootnode.config.publicaddr }}@$BOOTNODE_IP:30301
+          --bootnodes=enode://{{ .Values.bootnode.config.publicaddr }}@$BOOTNODE_IP:30399
       {{- if .Values.swarm.config.debug }}
           --debug
       {{- end }}


### PR DESCRIPTION
This was not complying with the NetworkPolicy.