### PR TITLE
jaeger: allow setting env vars

### DIFF
--- a/jaeger/templates/jaeger.deployment.yaml
+++ b/jaeger/templates/jaeger.deployment.yaml
@@ -30,6 +30,11 @@ spec:
         imagePullPolicy: {{ .Values.imagePullPolicy }}
         resources:
 {{ toYaml .Values.resources | indent 10 }}
+        env:
+        {{- range $key, $val := .Values.config.env }}
+          - name: {{ $key | quote}}
+            value: {{ $val | quote }}
+        {{- end }}
         args:
           - "--sampling.strategies-file=/etc/jaeger/sampling_strategies.json"
         {{- range .Values.config.args }}

--- a/jaeger/values.yaml
+++ b/jaeger/values.yaml
@@ -14,7 +14,9 @@ service:
     type: ClusterIP
 
 config:
-  # Custom CLI args passed to Jaeger
+  # Custom ENV and CLI args passed to Jaeger
+  env:
+    SPAN_STORAGE_TYPE: memory
   args:
     - "--memory.max-traces=100000"
 


### PR DESCRIPTION
This will become useful when we want to use another backend for storage (e.g. elasticsearch).