### PR TITLE
Jaeger: add collector service

### DIFF
--- a/jaeger/Chart.yaml
+++ b/jaeger/Chart.yaml
@@ -1,5 +1,5 @@
 name: jaeger
-version: 0.0.3
+version: 0.0.4
 description: Jaeger all-in-one launches the Jaeger UI, collector, query, and agent, with an in memory storage component.
 keywords:
 - instrumentation

--- a/jaeger/templates/jaeger-collector.service.yaml
+++ b/jaeger/templates/jaeger-collector.service.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "jaeger.fullname" . }}-collector
+  labels:
+    app: {{ template "jaeger.name" . }}
+    chart: {{ template "jaeger.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    component: jaeger
+spec:
+  type: {{ .Values.service.collector.type }}
+  selector:
+    app: {{ template "jaeger.name" . }}
+    release: {{ .Release.Name }}
+    component: jaeger
+  ports:
+    - name: grpc
+      port: 14250
+      protocol: TCP
+      targetPort: 14250
+    - name: tchannel
+      port: 14267
+      protocol: TCP
+      targetPort: 14267
+    - name: http-thrift
+      port: 14268
+      protocol: TCP
+      targetPort: 14268

--- a/jaeger/values.yaml
+++ b/jaeger/values.yaml
@@ -9,7 +9,7 @@ imagePullPolicy: IfNotPresent
 replicaCount: 1
 service:
   query:
-    type: NodePort
+    type: ClusterIP
   agent:
     type: ClusterIP
 

--- a/jaeger/values.yaml
+++ b/jaeger/values.yaml
@@ -12,6 +12,8 @@ service:
     type: ClusterIP
   agent:
     type: ClusterIP
+  collector:
+    type: ClusterIP
 
 config:
   # Custom ENV and CLI args passed to Jaeger


### PR DESCRIPTION
By exposing the collector service, we can start running multiple jaeger agents that run close to the applications and use those to send the spans via `gRPC` to the collector service.

The idea is that we'll start running the jaeger agents within the swarm pods and have them sending the spans via `gRPC` to the jaeger collector.