### PR TITLE
add a preinstall hook to the secrets

### DIFF
--- a/swarm/templates/swarm.secret.yaml
+++ b/swarm/templates/swarm.secret.yaml
@@ -1,6 +1,8 @@
 apiVersion: v1
 kind: Secret
 metadata:
+  annotations:
+    "helm.sh/hook": pre-install
   name: {{ template "swarm.fullname" . }}
   labels:
     app: {{ template "swarm.name" . }}


### PR DESCRIPTION
If this doesn't interfere with your workflow it would lower the entry barrier for folks that are just wanting to explore running nodes with minimal effort.