### PR TITLE
swarm: fix nodeSelector, affinity and tolerations

### DIFF
--- a/swarm-private/templates/bootnode.statefulset.yaml
+++ b/swarm-private/templates/bootnode.statefulset.yaml
@@ -27,6 +27,18 @@ spec:
 {{ toYaml .Values.bootnode.podAnnotations | indent 8 }}
         {{- end }}
     spec:
+{{- with .Values.bootnode.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+{{- end }}
+{{- with .Values.bootnode.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+{{- end }}
+{{- with .Values.bootnode.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+{{- end }}
       containers:
       - name: bootnode
         image: {{ .Values.bootnode.image.repository }}:{{ .Values.bootnode.image.tag }}
@@ -102,16 +114,4 @@ spec:
       storageClassName: "{{ .Values.bootnode.persistence.storageClass }}"
     {{- end }}
   {{- end }}
-{{- end }}
-{{- with .Values.bootnode.nodeSelector }}
-      nodeSelector:
-{{ toYaml . | indent 8 }}
-{{- end }}
-{{- with .Values.bootnode.affinity }}
-      affinity:
-{{ toYaml . | indent 8 }}
-{{- end }}
-{{- with .Values.bootnode.tolerations }}
-      tolerations:
-{{ toYaml . | indent 8 }}
 {{- end }}

--- a/swarm-private/templates/swarm.statefulset.yaml
+++ b/swarm-private/templates/swarm.statefulset.yaml
@@ -30,6 +30,18 @@ spec:
 {{ toYaml .Values.swarm.podAnnotations | indent 8 }}
         {{- end }}
     spec:
+{{- with .Values.swarm.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+{{- end }}
+{{- with .Values.swarm.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+{{- end }}
+{{- with .Values.swarm.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+{{- end }}
       terminationGracePeriodSeconds: {{ .Values.swarm.terminationGracePeriodSeconds }}
       containers:
       - name: swarm
@@ -146,16 +158,4 @@ spec:
       storageClassName: "{{ .Values.swarm.persistence.storageClass }}"
     {{- end }}
   {{- end }}
-{{- end }}
-{{- with .Values.swarm.nodeSelector }}
-      nodeSelector:
-{{ toYaml . | indent 8 }}
-{{- end }}
-{{- with .Values.swarm.affinity }}
-      affinity:
-{{ toYaml . | indent 8 }}
-{{- end }}
-{{- with .Values.swarm.tolerations }}
-      tolerations:
-{{ toYaml . | indent 8 }}
 {{- end }}

--- a/swarm/templates/swarm.statefulset.yaml
+++ b/swarm/templates/swarm.statefulset.yaml
@@ -30,6 +30,18 @@ spec:
 {{ toYaml .Values.swarm.podAnnotations | indent 8 }}
         {{- end }}
     spec:
+{{- with .Values.swarm.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+{{- end }}
+{{- with .Values.swarm.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+{{- end }}
+{{- with .Values.swarm.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+{{- end }}
       serviceAccountName: {{ template "swarm.fullname" . }}
       terminationGracePeriodSeconds: {{ .Values.swarm.terminationGracePeriodSeconds }}
       initContainers:
@@ -181,16 +193,4 @@ spec:
       storageClassName: "{{ .Values.swarm.persistence.storageClass }}"
     {{- end }}
   {{- end }}
-{{- end }}
-{{- with .Values.swarm.nodeSelector }}
-      nodeSelector:
-{{ toYaml . | indent 8 }}
-{{- end }}
-{{- with .Values.swarm.affinity }}
-      affinity:
-{{ toYaml . | indent 8 }}
-{{- end }}
-{{- with .Values.swarm.tolerations }}
-      tolerations:
-{{ toYaml . | indent 8 }}
 {{- end }}


### PR DESCRIPTION
These properties were ending up under `volumeClaimTemplates` when the persistence was set to `true`.

Should be under `sts.spec.template.spec`.