### PR TITLE
swarm/swarm-private: fix influxdb tags

### DIFF
--- a/swarm-private/templates/swarm.statefulset.yaml
+++ b/swarm-private/templates/swarm.statefulset.yaml
@@ -55,8 +55,8 @@ spec:
         - >
           export BOOTNODE_IP=$(nslookup {{ template "swarm.fullname" . }}-bootnode | grep Address | awk '{ print $3 }') &&
         {{- if .Values.swarm.metricsEnabled }}
-          export BZZKEY=$(sh swarm --password /keys/bzzaccount.password print-keys | grep bzzkey=    | cut -d '=' -f2 | cut -c1-7) &&
-          export PUBKEY=$(sh swarm --password /keys/bzzaccount.password print-keys | grep publicKey= | cut -d '=' -f2 | cut -c1-10) &&
+          export BZZKEY=$(swarm --password /keys/bzzaccount.password print-keys | grep bzzkey=    | cut -d '=' -f2 | cut -c1-7) &&
+          export PUBKEY=$(swarm --password /keys/bzzaccount.password print-keys | grep publicKey= | cut -d '=' -f2 | cut -c1-10) &&
         {{- end }}
           swarm
           --password /keys/bzzaccount.password

--- a/swarm/templates/swarm.statefulset.yaml
+++ b/swarm/templates/swarm.statefulset.yaml
@@ -70,8 +70,8 @@ spec:
         - >
           source /env/swarm.env;
         {{- if .Values.swarm.metricsEnabled }}
-          export BZZKEY=$(sh swarm --password /keys/bzzaccount.password print-keys | grep bzzkey=    | cut -d '=' -f2 | cut -c1-7) &&
-          export PUBKEY=$(sh swarm --password /keys/bzzaccount.password print-keys | grep publicKey= | cut -d '=' -f2 | cut -c1-10) &&
+          export BZZKEY=$(swarm --password /keys/bzzaccount.password print-keys | grep bzzkey=    | cut -d '=' -f2 | cut -c1-7) &&
+          export PUBKEY=$(swarm --password /keys/bzzaccount.password print-keys | grep publicKey= | cut -d '=' -f2 | cut -c1-10) &&
         {{- end }}
           swarm
           --password /keys/bzzaccount.password


### PR DESCRIPTION
No need to use `sh`. Currently it's showing: 

```
sh: can't open 'swarm': No such file or directory
```

This change should fix the problem since the swarm binary is already inside the PATH.