### PR TITLE
swarm: new 0.0.5 version with bootnode and pod specific flags

### DIFF
--- a/swarm-private/templates/swarm.statefulset.yaml
+++ b/swarm-private/templates/swarm.statefulset.yaml
@@ -53,7 +53,7 @@ spec:
         - sh
         - -ac
         - >
-          export POD_FLAGS=$(cat "/flags/$POD_NAME")
+          export POD_FLAGS=$(cat "/flags/$POD_NAME") &&
           export BOOTNODE_IP=$(nslookup {{ template "swarm.fullname" . }}-bootnode | grep Address | awk '{ print $3 }') &&
         {{- if .Values.swarm.metricsEnabled }}
           export BZZKEY=$(swarm --password /keys/bzzaccount.password print-keys | grep bzzkey=    | cut -d '=' -f2 | cut -c1-7) &&

--- a/swarm/Chart.yaml
+++ b/swarm/Chart.yaml
@@ -1,5 +1,5 @@
 name: swarm
-version: 0.0.4
+version: 0.0.5
 description: Create an ethereum swarm cluster
 keywords:
 - ethereum

--- a/swarm/requirements.lock
+++ b/swarm/requirements.lock
@@ -7,6 +7,6 @@ dependencies:
   version: 3.8.3
 - name: jaeger
   repository: https://raw.githubusercontent.com/ethersphere/helm-charts-artifacts/master/
-  version: 0.0.4
-digest: sha256:6b255a029a64eb255f549a36b1b0a7cfaf7d128ca7592a42bdb8d6c10d37400d
-generated: "2019-08-21T13:50:40.584251559+02:00"
+  version: 0.0.7
+digest: sha256:9eda69903f3fb8dc0d97a143919e51cbabc22c9dbf29a97ed98802ac724e074e
+generated: "2019-09-25T13:33:59.591336076+02:00"

--- a/swarm/requirements.yaml
+++ b/swarm/requirements.yaml
@@ -11,6 +11,6 @@ dependencies:
 
   # Tracing
   - name: "jaeger"
-    version: 0.0.4
+    version: 0.0.7
     condition: swarm.tracingEnabled
     repository: https://raw.githubusercontent.com/ethersphere/helm-charts-artifacts/master/

--- a/swarm/templates/bootnode.secret.yaml
+++ b/swarm/templates/bootnode.secret.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.bootnode.enabled -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "swarm.fullname" . }}-bootnode
+  labels:
+    app: {{ template "swarm.name" . }}
+    chart: {{ template "swarm.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    component: bootnode
+type: Opaque
+data:
+  bootnode.key: {{ .Values.bootnode.config.nodekey | b64enc | quote }}
+  bzzaccount.password: {{ .Values.swarm.secrets.password | b64enc | quote }}
+{{- end }}

--- a/swarm/templates/bootnode.service-headless.yaml
+++ b/swarm/templates/bootnode.service-headless.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.bootnode.enabled -}}
+kind: Service
+apiVersion: v1
+metadata:
+  name: {{ template "swarm.fullname" . }}-bootnode
+  labels:
+    app: {{ template "swarm.name" . }}
+    chart: {{ template "swarm.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    component: bootnode
+spec:
+  selector:
+    app: {{ template "swarm.name" . }}
+    release: {{ .Release.Name }}
+    component: bootnode
+  clusterIP: None
+  ports:
+  - name: network
+    port: 30399
+{{- end }}

--- a/swarm/templates/bootnode.statefulset.yaml
+++ b/swarm/templates/bootnode.statefulset.yaml
@@ -1,0 +1,121 @@
+{{- if .Values.bootnode.enabled -}}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ template "swarm.fullname" . }}-bootnode
+  labels:
+    app: {{ template "swarm.name" . }}
+    chart: {{ template "swarm.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    component: bootnode
+spec:
+  serviceName: {{ template "swarm.fullname" . }}-bootnode
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {{ template "swarm.name" . }}
+      release: {{ .Release.Name }}
+      component: bootnode
+  template:
+    metadata:
+      labels:
+        app: {{ template "swarm.name" . }}
+        release: {{ .Release.Name }}
+        component: bootnode
+        {{- if .Values.bootnode.podAnnotations }}
+      annotations:
+{{ toYaml .Values.bootnode.podAnnotations | indent 8 }}
+        {{- end }}
+    spec:
+{{- with .Values.bootnode.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+{{- end }}
+{{- with .Values.bootnode.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+{{- end }}
+{{- with .Values.bootnode.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+{{- end }}
+      containers:
+      - name: bootnode
+        image: {{ .Values.bootnode.image.repository }}:{{ .Values.bootnode.image.tag }}
+        imagePullPolicy: {{ .Values.bootnode.imagePullPolicy }}
+        resources:
+{{ toYaml .Values.bootnode.resources | indent 10 }}
+        command:
+        - sh
+        - -ac
+        - >
+          swarm
+          --debug
+          --bootnode-mode
+          --password /keys/bzzaccount.password
+          --nodekey=/keys/bootnode.key
+          --verbosity={{ .Values.bootnode.config.verbosity }}
+          --maxpeers=5000
+          --nat=ip:$POD_IP
+          --port=30399
+          --bzznetworkid={{ .Values.swarm.config.bzznetworkid }}
+          --bootnodes=""
+      {{- if .Values.swarm.tracingEnabled }}
+          --tracing
+          --tracing.endpoint=127.0.0.1:6831
+          --tracing.svc=$(POD_NAME)
+      {{- end }}
+{{- range $i, $flag := .Values.bootnode.config.extraFlags }}
+          {{ $flag }}
+{{- end }}
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        ports:
+        - name: network
+          containerPort: 30399
+        volumeMounts:
+        - name: keys
+          mountPath: /keys
+          readOnly: true
+        - name: data
+          mountPath: /root/.ethereum
+      volumes:
+      - name: keys
+        secret:
+          secretName: {{ template "swarm.fullname" . }}-bootnode
+{{- if not .Values.bootnode.persistence.enabled }}
+      - name: data
+        emptyDir: {}
+{{- else }}
+  volumeClaimTemplates:
+  - metadata:
+      name: data
+      labels:
+        app: {{ template "swarm.name" . }}
+        release: "{{ .Release.Name }}"
+        heritage: "{{ .Release.Service }}"
+        component: bootnode
+    spec:
+      accessModes:
+        - {{ .Values.bootnode.persistence.accessMode | quote }}
+      resources:
+          requests:
+            storage: {{ .Values.bootnode.persistence.size | quote }}
+  {{- if .Values.bootnode.persistence.storageClass }}
+    {{- if (eq "-" .Values.bootnode.persistence.storageClass) }}
+      storageClassName: ""
+    {{- else }}
+      storageClassName: "{{ .Values.bootnode.persistence.storageClass }}"
+    {{- end }}
+  {{- end }}
+{{- end }}
+
+{{- end }}

--- a/swarm/templates/podflags.configmap.yaml
+++ b/swarm/templates/podflags.configmap.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "swarm.fullname" . }}-podflags
+  labels:
+    app: {{ template "swarm.name" . }}
+    chart: {{ template "swarm.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+data:
+{{- range $key, $value := .Values.swarm.config.podSpecificFlags }}
+  {{ $key | lower }}: {{ $value }}
+{{- end }}

--- a/swarm/templates/swarm.statefulset.yaml
+++ b/swarm/templates/swarm.statefulset.yaml
@@ -68,6 +68,7 @@ spec:
         - sh
         - -ac
         - >
+          export POD_FLAGS=$(cat "/flags/$POD_NAME")
           source /env/swarm.env;
         {{- if .Values.swarm.metricsEnabled }}
           export BZZKEY=$(swarm --password /keys/bzzaccount.password print-keys | grep bzzkey=    | cut -d '=' -f2 | cut -c1-7) &&
@@ -115,6 +116,7 @@ spec:
 {{- range $i, $flag := .Values.swarm.config.extraFlags }}
           {{ $flag }}
 {{- end }}
+          $POD_FLAGS
         env:
         - name: POD_NAME
           valueFrom:
@@ -142,6 +144,9 @@ spec:
         - name: envshare
           mountPath: /env
           readOnly: true
+        - name: flags
+          mountPath: /flags
+          readOnly: true
       - name: proxy
         image: alpine/socat:1.0.3
         command: [ "sh", "-c", "source /env/swarm.env; exec socat tcp-listen:30399,reuseaddr,fork tcp:localhost:$NODEPORT"]
@@ -163,6 +168,9 @@ spec:
           - --reporter.grpc.retry.max=10
       {{- end }}
       volumes:
+      - name: flags
+        configMap:
+          name: {{ template "swarm.fullname" . }}-podflags
       - name: keys
         secret:
           secretName: {{ template "swarm.fullname" . }}

--- a/swarm/templates/swarm.statefulset.yaml
+++ b/swarm/templates/swarm.statefulset.yaml
@@ -68,8 +68,11 @@ spec:
         - sh
         - -ac
         - >
-          export POD_FLAGS=$(cat "/flags/$POD_NAME")
           source /env/swarm.env;
+          export POD_FLAGS=$(cat "/flags/$POD_NAME") &&
+        {{- if .Values.bootnode.enabled }}
+          export BOOTNODE_IP=$(nslookup {{ template "swarm.fullname" . }}-bootnode | grep Address | awk '{ print $3 }') &&
+        {{- end }}
         {{- if .Values.swarm.metricsEnabled }}
           export BZZKEY=$(swarm --password /keys/bzzaccount.password print-keys | grep bzzkey=    | cut -d '=' -f2 | cut -c1-7) &&
           export PUBKEY=$(swarm --password /keys/bzzaccount.password print-keys | grep publicKey= | cut -d '=' -f2 | cut -c1-10) &&
@@ -83,16 +86,16 @@ spec:
           --corsdomain=*
           --httpaddr=0.0.0.0
           --wsport=8546
+          --nat=extip:$PUBLIC_IP
           --verbosity={{ .Values.swarm.config.verbosity }}
           --maxpeers={{ .Values.swarm.config.maxpeers }}
           --ipcpath=bzzd.ipc
+          --bzznetworkid={{ .Values.swarm.config.bzznetworkid }}
+          {{- if .Values.bootnode.enabled }}
+          --bootnodes=enode://{{ .Values.bootnode.config.publicaddr }}@$BOOTNODE_IP:30399
+          {{- end }}
           {{- if .Values.swarm.config.debug }}
           --debug
-          {{- end }}
-          --bzznetworkid={{ .Values.swarm.config.bzznetworkid }}
-          --nat=extip:$PUBLIC_IP
-          {{- if gt (len .Values.swarm.config.bootnodes) 0 }}
-          --bootnodes={{- range $i, $b := .Values.swarm.config.bootnodes }}{{if ne $i 0}},{{end}}{{ $b }}{{- end }}
           {{- end }}
           {{- if .Values.swarm.metricsEnabled }}
           --metrics

--- a/swarm/values.yaml
+++ b/swarm/values.yaml
@@ -46,11 +46,6 @@ swarm:
     bzznetworkid: 3
     # LevelDB Store size - by default 4kb * 10^5 == 400 megabytes
     storesize: 100000
-    # List of bootnodes. Example configuration:
-    #bootnodes:
-    # - enode://xxxxxx@10.0.1.5:30399
-    # - enode://yyyyyy@10.0.1.7:30399
-    bootnodes: []
     extraFlags: []
     # Pod specific flags (Key: Pod name, Value: flags)
     # With this you can provide certain pods with flags without applying it to all the others.
@@ -119,6 +114,53 @@ swarm:
       limits:
         memory: 64Mi
         cpu: 0.1
+
+bootnode:
+  # When enabled, we'll deploy a bootnode.
+  # This ony makes sense if you're not connecting to the default public testnet.
+  # Can be useful if you want to create your own public network. The swarm nodes will
+  # then use this bootnode to initialize their connections.
+  enabled: false
+  # Image configuration
+  image:
+    repository: ethersphere/swarm
+    tag: latest
+  ## Specify a imagePullPolicy
+  ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
+  ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
+  ##
+  imagePullPolicy: Always
+  ## (dict) If specified, apply these annotations to the bootnode pod
+  # podAnnotations:
+  #   fluentbit.io/exclude: "true"
+  config:
+    verbosity: 3
+    publicaddr: 846c424961adc146d54861bdf1eb6015e6908b689fd12d01c61307fffc848c22e514f5c898dc9243fbb17aa80750b556772599d84fe86a4b715f40ebc4c049bf
+    nodekey: 09a28f7be03b782768ae2a8e2de90e7e27cd643a60f2a68e57514097bfa23566
+    extraFlags: []
+  persistence:
+    ## this enables PVC templates that will create one per pod
+    enabled: false
+    ## swarm data Persistent Volume Storage Class
+    ## If defined, storageClassName: <storageClass>
+    ## If set to "-", storageClassName: "", which disables dynamic provisioning
+    ## If undefined (the default) or set to null, no storageClassName spec is
+    ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
+    ##   GKE, AWS & OpenStack)
+    ##
+    # storageClass: "-"
+    accessMode: ReadWriteOnce
+    size: 1Gi
+  ## Configure resource requests and limits
+  ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
+  resources: {}
+  ## Node labels and tolerations for pod assignment
+  ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
+  ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#taints-and-tolerations-beta-feature
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+
 
 jaeger:
   image:

--- a/swarm/values.yaml
+++ b/swarm/values.yaml
@@ -52,6 +52,13 @@ swarm:
     # - enode://yyyyyy@10.0.1.7:30399
     bootnodes: []
     extraFlags: []
+    # Pod specific flags (Key: Pod name, Value: flags)
+    # With this you can provide certain pods with flags without applying it to all the others.
+    # Important: These flags will be visible under the /flags/ directory on all your pods.
+    #            Be careful if you use this to provide secret information. All pods can see the flags.
+    podSpecificFlags: {}
+      # swarm-0: --store.cache.size=10000 --maxpeers=100
+      # swarm-5: --maxpeers=60
 
   secrets:
      # Used to setup a sample Ethereum account in the data directory.
@@ -290,7 +297,7 @@ influxdb:
   ## ref: https://docs.influxdata.com/influxdb/v1.1/administration/config/
   config:
     reporting_disabled: false
-    
+
     storage_directory: /var/lib/influxdb
     rpc:
       enabled: true


### PR DESCRIPTION
These changes are relevant to the swarm chart (public cluster that exposes the swarm nodes).

- Update jaeger
- Added the pod specific flags option
- Added option to start a bootnode. Useful when deploying a public testnet. 

For now the bootnode is not exposed to the outside because it doesn't seem to be required.
All the other swarm nodes are exposed via public IPs and these can be used as bootnodes by clients that want to connect to the test cluster.