### PR TITLE
geth: use localhost for default rpc cors domains

### DIFF
--- a/geth/values.yaml
+++ b/geth/values.yaml
@@ -34,9 +34,9 @@ geth:
     # API's offered over the HTTP-RPC interface
     rpcapi: eth,net,web3,txpool
     # Comma separated list of domains from which to accept cross origin requests (browser enforced)
-    rpccorsdomains: "*"
+    rpccorsdomains: "localhost"
     # Comma separated list of virtual hostnames from which to accept requests (server enforced). Accepts '*' wildcard. (default: "localhost")
-    rpcvhosts: "*"
+    rpcvhosts: "localhost"
     # Megabytes of memory allocated to internal caching (default: 1024)
     cache: "1024"
     # Enable the WS-RPC server


### PR DESCRIPTION
fixes https://github.com/ethersphere/helm-charts/issues/1 