### PR TITLE
geth, jaeger: use stable apis 

### DIFF
--- a/geth/Chart.yaml
+++ b/geth/Chart.yaml
@@ -1,5 +1,5 @@
 name: geth
-version: 0.0.1
+version: 0.0.2
 description: Run geth (go ethereum client)
 keywords:
 - ethereum

--- a/geth/templates/ethstats.deployment.yaml
+++ b/geth/templates/ethstats.deployment.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.ethstats.enabled }}
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "geth.fullname" . }}-ethstats

--- a/jaeger/Chart.yaml
+++ b/jaeger/Chart.yaml
@@ -1,5 +1,5 @@
 name: jaeger
-version: 0.0.7
+version: 0.0.8
 description: Jaeger all-in-one launches the Jaeger UI, collector, query, and agent, with an in memory storage component.
 keywords:
 - instrumentation

--- a/jaeger/templates/jaeger.deployment.yaml
+++ b/jaeger/templates/jaeger.deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "jaeger.fullname" . }}


### PR DESCRIPTION
`apps/v1beta2` has been deprecated on Kubernetes v1.16.

A followup PR will exist for the swarm charts, to update the jaeger dependency. 

Related to https://github.com/ethersphere/helm-charts/issues/104 