### PR TITLE
swarm:  update jaeger deployment to use apps/v1 

### DIFF
--- a/swarm-private/Chart.yaml
+++ b/swarm-private/Chart.yaml
@@ -1,5 +1,5 @@
 name: swarm-private
-version: 0.0.5
+version: 0.0.6
 description: Create a private ethereum swarm cluster
 keywords:
 - ethereum

--- a/swarm-private/requirements.lock
+++ b/swarm-private/requirements.lock
@@ -16,6 +16,6 @@ dependencies:
   version: 3.8.3
 - name: jaeger
   repository: https://raw.githubusercontent.com/ethersphere/helm-charts-artifacts/master/
-  version: 0.0.7
-digest: sha256:9a2a9be919235bd21d787e8edcc82668eb42979ef7970ed7ccd2b42fd945bc3f
-generated: "2019-09-19T16:50:04.280581078+02:00"
+  version: 0.0.8
+digest: sha256:5e4563a4220e1db8c4593e2be70816d91576ca0a42e7f5895413cab34acfae76
+generated: "2019-10-24T11:21:13.599307677+02:00"

--- a/swarm-private/requirements.yaml
+++ b/swarm-private/requirements.yaml
@@ -24,6 +24,6 @@ dependencies:
 
   # Tracing
   - name: "jaeger"
-    version: 0.0.7
+    version: 0.0.8
     condition: swarm.tracingEnabled
     repository: https://raw.githubusercontent.com/ethersphere/helm-charts-artifacts/master/

--- a/swarm/Chart.yaml
+++ b/swarm/Chart.yaml
@@ -1,5 +1,5 @@
 name: swarm
-version: 0.0.5
+version: 0.0.6
 description: Create an ethereum swarm cluster
 keywords:
 - ethereum

--- a/swarm/requirements.lock
+++ b/swarm/requirements.lock
@@ -7,6 +7,6 @@ dependencies:
   version: 3.8.3
 - name: jaeger
   repository: https://raw.githubusercontent.com/ethersphere/helm-charts-artifacts/master/
-  version: 0.0.7
-digest: sha256:9eda69903f3fb8dc0d97a143919e51cbabc22c9dbf29a97ed98802ac724e074e
-generated: "2019-09-25T13:33:59.591336076+02:00"
+  version: 0.0.8
+digest: sha256:f8acd46f8765e296ce113b659b155051bb03cc65bcaa2fe3831d5e4580f47201
+generated: "2019-10-24T11:35:17.375042061+02:00"

--- a/swarm/requirements.yaml
+++ b/swarm/requirements.yaml
@@ -11,6 +11,6 @@ dependencies:
 
   # Tracing
   - name: "jaeger"
-    version: 0.0.7
+    version: 0.0.8
     condition: swarm.tracingEnabled
     repository: https://raw.githubusercontent.com/ethersphere/helm-charts-artifacts/master/


### PR DESCRIPTION
fixes https://github.com/ethersphere/helm-charts/issues/104 

Jaeger dependency has been updated to use `apps/v1` instead of `apps/v1beta2`.